### PR TITLE
Fix Apple Submission Failure

### DIFF
--- a/ios/RNTextInputMask/InputMask/InputMask.xcodeproj/project.pbxproj
+++ b/ios/RNTextInputMask/InputMask/InputMask.xcodeproj/project.pbxproj
@@ -522,7 +522,7 @@
 		8A808EE01D5B0FEC00A75B9C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -544,7 +544,7 @@
 		8A808EE11D5B0FEC00A75B9C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;

--- a/ios/RNTextInputMask/RNTextInputMask.xcodeproj/project.pbxproj
+++ b/ios/RNTextInputMask/RNTextInputMask.xcodeproj/project.pbxproj
@@ -285,7 +285,7 @@
 		00278A0A1F2F25CE0023E794 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				DEVELOPMENT_TEAM = YRYY3MUZEK;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../react-native/Libraries/Text/**";
 				OTHER_LDFLAGS = "-ObjC";
@@ -297,7 +297,7 @@
 		00278A0B1F2F25CE0023E794 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				DEVELOPMENT_TEAM = YRYY3MUZEK;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../react-native/Libraries/Text/**";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Submission to Apple was failing because this library isn't set up as a proper static library and pulls in some frameworks, which triggers a failure to upload to the App Store. Removing the mandatory Swift library embedding fixes this.

See https://github.com/react-native-community/react-native-text-input-mask/issues/79 for more information.